### PR TITLE
fixed hour constant in Time.hs

### DIFF
--- a/src/FRP/Helm/Time.hs
+++ b/src/FRP/Helm/Time.hs
@@ -37,7 +37,7 @@ minute = 60000
 
 {-| A time value representing one hour. -}
 hour :: Time
-hour = 60000
+hour = 3600000
 
 {-| Converts a time value to a fractional value, in milliseconds. -}
 inMilliseconds :: Time -> Double


### PR DESCRIPTION
Fixed so hour function in FRP.Helm.Time module is correct. At the moment hour is the same as minute.
