### PR TITLE
Multiplying form scale instead of adding it

### DIFF
--- a/src/FRP/Helm/Graphics.hs
+++ b/src/FRP/Helm/Graphics.hs
@@ -208,7 +208,7 @@ rotate t f = f { formTheta = t + formTheta f }
 
 {-| Scales a form by an amount, e.g. scaling by /2.0/ will double the size. -}
 scale :: Double -> Form -> Form
-scale n f = f { formScale = n + formScale f }
+scale n f = f { formScale = n * formScale f }
 
 {-| Moves a form relative to its current position. -}
 move :: (Double, Double) -> Form -> Form


### PR DESCRIPTION
Currently `scale 2` actually triples the size of a form, because it adds instead of multiplies.
