### PR TITLE
Did some changes to run and added runA

### DIFF
--- a/src/FRP/Helm.hs
+++ b/src/FRP/Helm.hs
@@ -5,6 +5,7 @@ module FRP.Helm (
   Time,
   -- * Engine
   run,
+  runA,
   -- * Utilities
   radians,
   degrees,
@@ -87,9 +88,14 @@ newEngineState smp = do
     > main = run $ fmap (fmap render) Window.dimensions
  -}
 run :: SignalGen (Signal Element) -> IO ()
-run gen = finally SDL.quit $ do
+run = runA 800 600 "Helm"
+
+{-| Same as run, but takes arguments for width, height and window title -}
+runA :: Int -> Int -> String -> SignalGen (Signal Element) -> IO ()
+runA w h t gen = finally SDL.quit $ do
   SDL.init [SDL.InitVideo, SDL.InitJoystick]
-  requestDimensions 800 600
+  requestDimensions w h
+  SDL.rawSetCaption (Just t) Nothing
   start gen >>= newEngineState >>= run'
 
 {-| A utility function called by 'run' that samples the element


### PR DESCRIPTION
Read runA as runAdvanced. Okey, now it's a bit more useful since you get choose initial window size and title.

I suggest something like this for a better run engine function: It parses a config file(we could use Data.Configurator or probably preferably using json?) that has window size etc. This file could be change in runtime. If the config file stuff is in seperated module it could also be used for stuff like saved games etc. and also have easy support for handling filesystems across platforms(*nix uses .gamename/ for files, windows using C:\Users\user\Saved Games\gamename etc. etc.). This is just suggestion.

Also, maybe have option to only not allow the window to be resizeable and also have an option for fullscreen is needed i guess. I could probably implement that as good as I can but now I have to head to the gym.
