### PR TITLE
FRP.Helm.Animation doesn't accept empty lists anymore.

### DIFF
--- a/src/FRP/Helm/Animation.hs
+++ b/src/FRP/Helm/Animation.hs
@@ -9,7 +9,10 @@ module FRP.Helm.Animation (
   -- * Animating
   animate,
   formAt,
-  length
+  length,
+  (!:),
+  (!!:),
+  frames
 ) where
 
 import Prelude hiding (length)
@@ -26,25 +29,45 @@ import Data.List (find)
     actually looks when rendered. -}
 type Frame = (Time, Form)
 
-{-| A type describing an animation consisting of a list of frames. -}
+{-| A type describing a list of frames.
+    The frames are rendered from left to right. -}
+newtype Frames = Frames [Frame]
+
+{-| Prepends a frame to a list of frames. -}
+(!:) :: Frame -> Frames -> Frames
+(!:) f (Frames fs) = Frames (f:fs)
+
+infixr 5 !:
+
+{-| Creates a list of frames out of two frames. -}
+(!!:) :: Frame -> Frame -> Frames
+(!!:) f1 f2 = Frames ([f1,f2])
+
+infixr 5 !!:
+
+{-| Turns a frame into a list of one frame. -}
+frames :: Frame -> Frames
+frames f = Frames [f]
+
+{-| A type describing an animation consisting of a list of frames.
+    Can be assumed to be non-empty.-}
 newtype Animation = Animation [Frame] deriving (Show, Eq)
 
 {-| Creates an animation from a list of frames. The time value in each frame
     is absolute to the entire animation, i.e. each time value is the time
     at which the frame takes place relative to the starting time of the animation.
-    The list of frames should never be empty.
  -}
-absolute :: [Frame] -> Animation
-absolute = Animation
+absolute :: Frames -> Animation
+absolute (Frames fs) = Animation fs
 
 {-| Creates an animation from a list of frames. The time value in each frame
     is relative to other frames, i.e. each time value is the difference
-    in time from the last frame. The list of frames should never be empty.
+    in time from the last frame.
 
     > relative [(100, picture1), (100, picture2), (300, picture3)] == absolute [(100, picture1), (200, picture2), (500, picture3)]
  -}
-relative :: [Frame] -> Animation
-relative frames = Animation $ scanl1 (\acc x -> (fst acc + fst x, snd x)) frames
+relative :: Frames -> Animation
+relative (Frames fs) = Animation $ scanl1 (\acc x -> (fst acc + fst x, snd x)) fs
 
 {-| Creates a signal contained in a generator that returns the current form in the animation when sampled from
     a specific animation. The second argument is a signal generator containing a signal that


### PR DESCRIPTION
I've also changed a function name unexposed to the user and removed the empty list warnings in the comments.
Fixed a little mistake with resetting the animations.
I had to make up a little DSL for the creation of nonempty lists. Better ideas appreciated.
