### PR TITLE
Fixed Animation.hs exports

### DIFF
--- a/src/FRP/Helm/Animation.hs
+++ b/src/FRP/Helm/Animation.hs
@@ -12,7 +12,8 @@ module FRP.Helm.Animation (
   frames,
   -- * Animating
   animate,
-  formAt
+  formAt,
+  length
 ) where
 
 import Prelude hiding (length)
@@ -106,4 +107,3 @@ resetOnEnd' :: Time -> Time -> Time
 resetOnEnd' l t
   | t >= l = 0
   | otherwise = t
-  


### PR DESCRIPTION
!:,etc... functions where in animating instead of creating.
Also the constructor of Animation should not be exported, since empty Animations could be created leading to an error.
Didn't sleep again, so I got confused, sorry.
