### PR TITLE
Balance createTexture with destroyTexture

### DIFF
--- a/src/FRP/Helm.hs
+++ b/src/FRP/Helm.hs
@@ -150,6 +150,7 @@ render engine@(Engine { .. }) element = alloca $ \wptr      ->
 
   SDL.renderClear renderer
   SDL.renderCopy renderer texture nullPtr nullPtr
+  SDL.destroyTexture texture
   SDL.renderPresent renderer
 
 


### PR DESCRIPTION
Running the moving-square example on OS X was leaking hundreds of megs of memory per second! Appears a `destroyTexture` call managed to slip away into some dark night.
