### PR TITLE
Lower upper version bounds on sdl2

### DIFF
--- a/helm.cabal
+++ b/helm.cabal
@@ -48,7 +48,7 @@ library
     containers >= 0.5 && < 1,
     elerea >= 2.7 && < 3,
     filepath >= 1.3 && < 2,
-    sdl2 >= 1.1 && < 2,
+    sdl2 >= 1.1 && < 1.3,
     text >= 1.1.1.3,
     time >= 1.4 && < 1.5,
     random >= 1.0.1.1 && < 1.2,
@@ -77,4 +77,4 @@ test-suite helm-tests
     test-framework-quickcheck2 >= 0.3 && < 1,
     time >= 1.4 && < 1.5,
     elerea >= 2.7 && < 3,
-    sdl2 >= 1.1 && < 2
+    sdl2 >= 1.1 && < 1.3


### PR DESCRIPTION
According to the package versioning policy, the upper two numbers in a package's version are to be incremented on API incompatible changes.

The version constraint on the `sdl2` package is too broad, `helm` may not work with newer versions of `sdl2` in the future. This patch is precautionary.
