### PR TITLE
Fixed issue #82 (Initial delta of Time.fps on Mac)

### DIFF
--- a/helm.cabal
+++ b/helm.cabal
@@ -1,5 +1,5 @@
 name: helm
-version: 0.7.0
+version: 0.7.1
 synopsis: A functionally reactive game engine.
 description: A functionally reactive game engine, with headgear to protect you
              from the headache of game development provided.

--- a/src/FRP/Helm/Time.hs
+++ b/src/FRP/Helm/Time.hs
@@ -102,9 +102,11 @@ every' t = Signal $ every'' t >>= transfer (pure (0,0)) update
 {-| Another utility signal that does all the magic for 'every'' by working on
     the Elerea SignalGen level -}
 every'' :: Time -> SignalGen p (Elerea.Signal (Time, Time))
-every'' t = getTime >>= transfer (0,0) update_
+every'' t = do
+    it <- execute getTime
+    effectful getTime >>= transfer (it,0) update_
   where
-    getTime = effectful $ liftM ((second *) . realToFrac) getPOSIXTime
+    getTime = liftM ((second *) . realToFrac) getPOSIXTime
     update_ _ new old = let delta = new - fst old
                         in if delta >= t then (new, delta) else old
 


### PR DESCRIPTION
The issue can be found here: https://github.com/switchface/helm/issues/82

The problem was that every function that called every'' (inside
FRP.Helm.Time) would get back the current timestamp as a first delta.

It's much more reasonable to have it return `0` as a first delta,
instead; especially in games where an initial update of 1419151612000
milliseconds could screw up the initial state. As an example, assuming a
simple snake game, an initial update of 1419151612 seconds in a snake
game could move the snake out of the bounds (and therefore make the
player lose) at the first "tick".

This commit aims at solving exactly this problem, by gathering the
initial timestamp to pass as the initial argument of `transfer`.
