### PR TITLE
Ported to lts-5.5, biggest changes from sdl2 1.x -> 2.x

### DIFF
--- a/helm.cabal
+++ b/helm.cabal
@@ -1,5 +1,5 @@
 name: helm
-version: 0.7.1
+version: 0.8.0
 synopsis: A functionally reactive game engine.
 description: A functionally reactive game engine, with headgear to protect you
              from the headache of game development provided.
@@ -7,7 +7,7 @@ homepage: http://github.com/switchface/helm
 bug-reports: http://github.com/switchface/helm/issues
 license: MIT
 license-file: LICENSE
-tested-with: GHC == 7.6.3
+tested-with: GHC == 7.10.3
 extra-source-files: LICENSE, README.md
 author: Zack Corr
 maintainer: Zack Corr <zack@z0w0.me>
@@ -43,18 +43,19 @@ library
 
   build-depends:
     base >= 4 && < 5,
-    cairo > 0.12 && < 0.13,
-    pango > 0.12 && < 0.13,
+    cairo >= 0.13 && < 0.14,
+    pango >= 0.13 && < 0.14,
     containers >= 0.5 && < 1,
     elerea >= 2.7 && < 3,
     filepath >= 1.3 && < 2,
-    sdl2 >= 1.1 && < 1.3,
-    text >= 1.1.1.3,
-    time >= 1.4 && < 1.5,
+    sdl2 >= 2 && < 3,
+    text >= 1.1.1.3 && < 2,
+    time >= 1.4 && < 2,
     random >= 1.0.1.1 && < 1.2,
-    mtl >= 2.1 && < 2.2,
-    transformers >= 0.3.0.0,
-    cpu >= 0.1.2 && < 1
+    mtl >= 2.1 && < 3,
+    transformers >= 0.3.0.0 && < 0.5,
+    cpu >= 0.1.2 && < 1,
+    linear >= 1 && < 2
 
   if impl(ghc < 7.6)
     build-depends: ghc-prim
@@ -69,12 +70,12 @@ test-suite helm-tests
 
   build-depends:
     base >= 4 && < 5,
-    cairo > 0.12 && < 0.13,
+    cairo >= 0.13 && < 0.14,
     containers >= 0.5 && < 1,
     HUnit >= 1.2 && < 2,
     test-framework >= 0.8 && < 1,
     test-framework-hunit >= 0.3 && < 1,
     test-framework-quickcheck2 >= 0.3 && < 1,
-    time >= 1.4 && < 1.5,
+    time >= 1.4 && < 2,
     elerea >= 2.7 && < 3,
-    sdl2 >= 1.1 && < 1.3
+    sdl2 >= 2 && < 3

--- a/src/FRP/Helm/Engine.hs
+++ b/src/FRP/Helm/Engine.hs
@@ -1,11 +1,11 @@
 module FRP.Helm.Engine where
-import qualified Graphics.UI.SDL as SDL
+import qualified SDL.Video as Video
 import qualified Graphics.Rendering.Cairo as Cairo
 import qualified Data.Map as Map
 {-| A data structure describing the current engine state. -}
 data Engine = Engine {
-  window   :: SDL.Window,
-  renderer :: SDL.Renderer,
+  window   :: Video.Window,
+  renderer :: Video.Renderer,
   cache    :: Map.Map FilePath Cairo.Surface,
   continue :: Bool
 }

--- a/src/FRP/Helm/Keyboard.hs
+++ b/src/FRP/Helm/Keyboard.hs
@@ -8,7 +8,6 @@ module FRP.Helm.Keyboard (
   arrows, wasd
 ) where
 
-import Control.Applicative
 import Data.List
 import Foreign hiding (shift)
 import Foreign.C.Types
@@ -790,4 +789,3 @@ wasd = arrows' <$> w <*> a <*> s <*> d
         a = isDown AKey
         s = isDown SKey
         d = isDown DKey
-

--- a/src/FRP/Helm/Mouse.hs
+++ b/src/FRP/Helm/Mouse.hs
@@ -1,8 +1,6 @@
 {-| Contains signals that sample input from the mouse. -}
 module FRP.Helm.Mouse
 (
-  -- * Types
-  Mouse(..),
   -- * Position
   position, x, y,
   -- * Mouse State
@@ -11,48 +9,19 @@ module FRP.Helm.Mouse
   clicks
 ) where
 
-import Control.Applicative (pure)
-import Data.Bits
-import Foreign.Marshal.Alloc
-import Foreign.Ptr
-import Foreign.Storable
 import FRP.Elerea.Param hiding (Signal)
 import FRP.Helm.Sample
 import FRP.Helm.Signal
-import qualified Graphics.UI.SDL as SDL
-
-{-| A data structure describing a button on a mouse. -}
-data Mouse
-  = LeftMouse
-  | MiddleMouse
-  | RightMouse
-  | X1Mouse
-  | X2Mouse deriving (Show, Eq, Ord, Read)
-
-{- All integer values of this enum are equivalent to the SDL key enum. -}
-instance Enum Mouse where
-  fromEnum LeftMouse   = 1
-  fromEnum MiddleMouse = 2
-  fromEnum RightMouse  = 3
-  fromEnum X1Mouse     = 4
-  fromEnum X2Mouse     = 5
-
-  toEnum 1 = LeftMouse
-  toEnum 2 = MiddleMouse
-  toEnum 3 = RightMouse
-  toEnum 4 = X1Mouse
-  toEnum 5 = X2Mouse
-  toEnum _ = error "FRP.Helm.Mouse.Mouse.toEnum: bad argument"
+import SDL.Input.Mouse
+import Linear.V2 (V2(V2))
+import Linear.Affine (Point(P))
 
 {-| The current position of the mouse. -}
 position :: Signal (Int, Int)
 position = Signal $ getPosition >>= transfer (pure (0,0)) update
   where
-    getPosition = effectful $ alloca $ \xptr -> alloca $ \yptr -> do
-      _ <- SDL.getMouseState xptr yptr
-      x_ <- peek xptr
-      y_ <- peek yptr
-
+    getPosition = effectful $ do
+      P (V2 x_ y_) <- getAbsoluteMouseLocation
       return (fromIntegral x_, fromIntegral y_)
 
 {-| The current x-coordinate of the mouse. -}
@@ -66,21 +35,19 @@ y = snd <~ position
 {-| The current state of the left mouse-button. True when the button is down,
     and false otherwise. -}
 isDown :: Signal Bool
-isDown = isDownButton LeftMouse
+isDown = isDownButton ButtonLeft
 
 {-| The current state of a given mouse button. True if down, false otherwise.
     -}
-isDownButton :: Mouse -> Signal Bool
-isDownButton m = Signal $ getDown >>= transfer (pure False) update
+isDownButton :: MouseButton -> Signal Bool
+isDownButton btn = Signal $ getDown >>= transfer (pure False) update
   where
     getDown = effectful $ do
-      flags <- SDL.getMouseState nullPtr nullPtr
-
-      return $ (.&.) (fromIntegral flags) (fromEnum m) /= 0
+      btnMap <- getMouseButtons
+      return (btnMap btn)
 
 {-| Always equal to unit. Event triggers on every mouse click. -}
 clicks :: Signal ()
 clicks = Signal $ signalGen isDown >>= transfer (pure ()) update_
   where update_ _ (Changed True) _ = Changed ()
         update_ _ _ _              = Unchanged ()
-

--- a/src/FRP/Helm/Random.hs
+++ b/src/FRP/Helm/Random.hs
@@ -4,7 +4,6 @@ module FRP.Helm.Random (
   float,
   floatList
 ) where
-import Control.Applicative (pure)
 import Control.Monad (liftM, join, replicateM)
 import FRP.Elerea.Param hiding (Signal)
 import qualified FRP.Elerea.Param as Elerea (Signal)

--- a/src/FRP/Helm/Signal.hs
+++ b/src/FRP/Helm/Signal.hs
@@ -23,7 +23,7 @@ module FRP.Helm.Signal(
   lift8
 ) where
 import Control.Applicative
-import Data.Traversable (sequenceA)
+
 import FRP.Elerea.Param hiding (Signal)
 import qualified FRP.Elerea.Param as Elerea (Signal)
 import FRP.Helm.Sample
@@ -60,8 +60,8 @@ merge s1 s2 = Signal $ do
   s2' <- signalGen s2
   return $ update' <$> s1' <*> s2'
     where update' (Changed   x) _             = Changed x
-          update' (Unchanged x) (Changed y)   = Changed y
-          update' (Unchanged x) (Unchanged y) = Unchanged x
+          update' (Unchanged _) (Changed y)   = Changed y
+          update' (Unchanged x) (Unchanged _) = Unchanged x
 
 {-| Merge many signals into one. This is useful when you are merging more than
    two signals. When multiple updates come in at the same time, the left-most

--- a/src/FRP/Helm/Time.hs
+++ b/src/FRP/Helm/Time.hs
@@ -20,7 +20,7 @@ module FRP.Helm.Time (
   since
 ) where
 
-import Control.Applicative
+
 import Control.Monad
 import FRP.Elerea.Param hiding (delay, Signal, until)
 import qualified FRP.Elerea.Param as Elerea (Signal, until)

--- a/src/FRP/Helm/Window.hs
+++ b/src/FRP/Helm/Window.hs
@@ -7,14 +7,13 @@ module FRP.Helm.Window (
   position
 ) where
 
-import Control.Applicative (pure)
-import Foreign.Marshal.Alloc
-import Foreign.Storable
 import FRP.Elerea.Param hiding (Signal)
 import FRP.Helm.Engine
 import FRP.Helm.Sample
 import FRP.Helm.Signal
-import qualified Graphics.UI.SDL as SDL
+import SDL
+import qualified SDL.Video as Video
+import Linear.V2 (V2(V2))
 
 {-| The current dimensions of the window. -}
 dimensions :: Signal (Int, Int)
@@ -22,13 +21,9 @@ dimensions =
   Signal $ input >>= getDimensions >>= transfer (pure (0,0)) update
   where
     getDimensions = effectful1 action
-    action engine = alloca $ \wptr -> alloca $ \hptr -> do
-	  SDL.getWindowSize (window engine) wptr hptr
-
-	  w <- peek wptr
-	  h <- peek hptr
-
-	  return (fromIntegral w, fromIntegral h)
+    action engine = do
+      V2 w h <- SDL.get $ Video.windowSize (window engine)
+      return (fromIntegral w, fromIntegral h)
 
 {-| The current position of the window. -}
 position :: Signal (Int, Int)
@@ -36,13 +31,9 @@ position =
   Signal $ input >>= getPosition >>= transfer (pure (0,0)) update
   where
     getPosition = effectful1 action
-    action engine = alloca $ \xptr -> alloca $ \yptr -> do
-	  SDL.getWindowPosition (window engine) xptr yptr
-
-	  x <- peek xptr
-	  y <- peek yptr
-
-	  return (fromIntegral x, fromIntegral y)
+    action engine = do
+        V2 x y <- Video.getWindowAbsolutePosition (window engine)
+        return (fromIntegral x, fromIntegral y)
 
 {-| The current width of the window. -}
 width :: Signal Int

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,7 @@
 flags: {}
 packages:
-    - '.'
+- '.'
 extra-deps:
-    - elerea-2.8.0
-    - cairo-0.12.5.3
-    - utf8-string-0.3.8
-    - pango-0.12.5.3
-    - sdl2-1.2.0
-    - glib-0.12.5.4
-resolver: lts-2.14
+- elerea-2.8.0
+- text-1.2.2.0
+resolver: lts-5.5


### PR DESCRIPTION
- sdl2 now has higher level stuff that doesn't need manual allocation.
- API breakage in Mouse, now uses MouseButton type from sdl2 instead of
  own Mouse type.