### PR TITLE
bump transformers dependency to < 0.6

### DIFF
--- a/helm.cabal
+++ b/helm.cabal
@@ -53,7 +53,7 @@ library
     time >= 1.4 && < 2,
     random >= 1.0.1.1 && < 1.2,
     mtl >= 2.1 && < 3,
-    transformers >= 0.3.0.0 && < 0.5,
+    transformers >= 0.3.0.0 && < 0.6,
     cpu >= 0.1.2 && < 1,
     linear >= 1 && < 2
 


### PR DESCRIPTION
now builds with cabal and GHC 8