### PR TITLE
Update for Elerea 2.9.0, renamed until -> till

### DIFF
--- a/helm.cabal
+++ b/helm.cabal
@@ -46,7 +46,7 @@ library
     cairo >= 0.13 && < 0.14,
     pango >= 0.13 && < 0.14,
     containers >= 0.5 && < 1,
-    elerea >= 2.7 && < 3,
+    elerea >= 2.9.0 && < 3,
     filepath >= 1.3 && < 2,
     sdl2 >= 2 && < 3,
     text >= 1.1.1.3 && < 2,

--- a/src/FRP/Helm/Time.hs
+++ b/src/FRP/Helm/Time.hs
@@ -22,8 +22,8 @@ module FRP.Helm.Time (
 
 
 import Control.Monad
-import FRP.Elerea.Param hiding (delay, Signal, until)
-import qualified FRP.Elerea.Param as Elerea (Signal, until)
+import FRP.Elerea.Param hiding (delay, Signal, till)
+import qualified FRP.Elerea.Param as Elerea (Signal, till)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import FRP.Helm.Signal
 import FRP.Helm.Sample
@@ -134,10 +134,10 @@ delay t (Signal gen) = Signal $ (fmap . fmap) fst $
     update_ _ waiting new (old, olds) = if waiting then (old, new:olds)
                                         else (last olds, new:init olds)
     timeout = every'' t >>= transfer False (\_ (time,delta) _ -> time /= delta)
-                        -- 'Elerea.until' will lose the reference to the input so
+                        -- 'Elerea.till will lose the reference to the input so
                         -- we don't keep looking up the time even though the
                         -- output can never change again
-                        >>= Elerea.until
+                        >>= Elerea.till
                         >>= transfer True (\_ new old -> old && not new)
 
 {-| Takes a time t and any signal. The resulting boolean signal is true for


### PR DESCRIPTION
Elerea 2.9.0 renamed the `until` -> `till`. I renamed the instances, but you could also change the constraint to <2.9.0.