### PR TITLE
Fixed the last line of Polygons not being drawn

### DIFF
--- a/src/Helm/Engine/SDL/Graphics2D.hs
+++ b/src/Helm/Engine/SDL/Graphics2D.hs
@@ -154,7 +154,7 @@ renderForm Form { formPos = V2 x y, .. } = withTransform formScale formTheta x y
       case shape of
         PolygonShape (Path (~ps @ (V2 hx hy : _))) -> do
           Cairo.moveTo hx hy
-          mapM_ (\(V2 lx ly) -> Cairo.lineTo lx ly) ps
+          mapM_ (\(V2 lx ly) -> Cairo.lineTo lx ly) (ps ++ [head ps])
 
         RectangleShape (V2 w h) ->
           Cairo.rectangle (-w / 2) (-h / 2) w h


### PR DESCRIPTION
I noticed that `polygon` and also `ngon` didn't actually draw the last line (the one from the last point to the first point - so it drew things like [this](http://i.imgur.com/bI0E641.png)) without duplicating the first point of the polygon. The documentation of `polygon` states, that shouldn't be necessary though.

So I went into the code and changed the rendering of Polygons to duplicate the first point before rendering, which it didn't seem to be doing, thus causing this bug.

Afterwards I tested the same shapes and it drew them correctly again.