### PR TITLE
Restore the `hello` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ it globally will let you run the example Helm games. See the next section.
 
 ## Getting Started
 
-Check out the `examples` directory for some examples; the `flappy` example is a particularly good start.
-Unfortunately, there's little to no example games yet, so if you end up making something cool and lightweight
-that you'd think would be a good example, feel free to open a pull request!
+Check out the `examples` directory for some examples; the `hello` example is a
+particularly good start and `flappy` is a bit more advanced. We could always
+use more examples so if you end up making something cool and lightweight that
+you'd think would be a good one, feel free to open a pull request!
 
 If you have installed Helm globally using Stack, you can run the `flappy` example using:
 

--- a/examples/hello/Main.hs
+++ b/examples/hello/Main.hs
@@ -1,0 +1,37 @@
+import Linear.V2 (V2(V2))
+
+import Helm
+import Helm.Color
+import Helm.Engine.SDL (SDLEngine)
+import Helm.Graphics2D
+
+import qualified Helm.Cmd as Cmd
+import qualified Helm.Mouse as Mouse
+import qualified Helm.Engine.SDL as SDL
+
+data Action = Idle | ChangePosition (V2 Double)
+data Model = Model (V2 Double)
+
+initial :: (Model, Cmd SDLEngine Action)
+initial = (Model $ V2 0 0, Cmd.none)
+
+update :: Model -> Action -> (Model, Cmd SDLEngine Action)
+update model Idle = (model, Cmd.none)
+update _ (ChangePosition pos) = (Model pos, Cmd.none)
+
+subscriptions :: Sub SDLEngine Action
+subscriptions = Mouse.moves (\(V2 x y) -> ChangePosition $ V2 (fromIntegral x) (fromIntegral y))
+
+view :: Model -> Graphics SDLEngine
+view (Model pos) = Graphics2D $ collage [move pos $ filled (rgb 1 0 0) $ square 10]
+
+main :: IO ()
+main = do
+  engine <- SDL.startup
+
+  run engine GameConfig
+    { initialFn       = initial
+    , updateFn        = update
+    , subscriptionsFn = subscriptions
+    , viewFn          = view
+    }


### PR DESCRIPTION
I think the simple example is a much better starting point for newcomers. I am not sure why you deleted it. I had already started to re-implemented a simple example to try and understand the new Helm before I realised there used to be one!