### PR TITLE
Add the `hello` example to the cabal file

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ If you have installed Helm globally using Stack, you can run the `flappy` exampl
 stack exec helm-example-flappy
 ```
 
+Or the `hello` example using:
+
+```
+stack exec helm-example-hello
+```
+
 ## Documentation
 
 API documentation for the latest stable version of Helm is available on [Hackage](http://hackage.haskell.org/package/helm).

--- a/helm.cabal
+++ b/helm.cabal
@@ -73,6 +73,16 @@ executable helm-example-flappy
     random == 1.*,
     helm
 
+executable helm-example-hello
+  default-language: Haskell2010
+  main-is: Main.hs
+  hs-source-dirs: examples/hello
+
+  build-depends:
+    base >= 4 && < 5,
+    linear >= 1 && < 2,
+    helm
+
 test-suite helm-spec
   type: exitcode-stdio-1.0
   ghc-options: -Wall


### PR DESCRIPTION
This way the example can be compiled and run like the 'flappy' example

Just a super easy fix I found I could make! I look forward to contributing more to this library, it seems really awesome so far! Keep up the good work!