### PR TITLE
Add mouse wheel event

### DIFF
--- a/helm.cabal
+++ b/helm.cabal
@@ -53,7 +53,7 @@ library
     pango >= 0.13 && < 0.14,
     containers >= 0.5 && < 1,
     elerea >= 2.9 && < 3,
-    sdl2 > 2.1.1 && < 3,
+    sdl2 > 2.2 && < 3,
     linear >= 1 && < 2,
     text >= 1.1.1.3 && < 2,
     mtl >= 2.1 && < 3,

--- a/src/Helm/Engine.hs
+++ b/src/Helm/Engine.hs
@@ -59,6 +59,9 @@ class Engine e where
   -- | The mouse click signal, with events provided by the engine.
   mouseClickSignal :: e -> SignalGen e (Signal [(MouseButton, V2 Int)])
 
+  -- | The mouse wheel signal, with events provided by the engine.
+  mouseWheelSignal :: e -> SignalGen e (Signal [V2 Int])
+
   -- | The keyboard down signal, with events provided by the engine.
   keyboardDownSignal :: e -> SignalGen e (Signal [Key])
 

--- a/src/Helm/Mouse.hs
+++ b/src/Helm/Mouse.hs
@@ -8,6 +8,7 @@ module Helm.Mouse
   , clicks
   , downs
   , ups
+  , wheels
   ) where
 
 import FRP.Elerea.Param (input, snapshot)
@@ -60,3 +61,13 @@ ups f = Sub $ do
   engine <- input >>= snapshot
 
   fmap (fmap (uncurry f)) <$> mouseUpSignal engine
+
+-- | Subscribe to mouse wheel events and map to a game action
+wheels
+  :: Engine e
+  => (V2 Int -> a)  -- ^ The function to map a mouse wheel and wheel direction to an action.
+  -> Sub e a        -- ^ The mapped subscription
+wheels f = Sub $ do
+  engine <- input >>= snapshot
+
+  fmap (fmap f) <$> mouseWheelSignal engine

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,5 @@ packages:
 extra-deps:
   - elerea-2.9.0
   - text-1.2.2.0
-  - sdl2-2.1.3
+  - sdl2-2.2.0
 resolver: lts-8.18


### PR DESCRIPTION
Add the ability to track and subscribe to mouse wheel events. It will provide the network with the vector of the mouse direction (it seems to be always 0 1 or 0 -1 depending on the wheel move, but I have a limited amount of devices to test this).

- It means we need to bump the version of SDL2. I cannot guarantee, despite testing as much as I could, that this has no side-effect - but, once again, if there are, I couldn't find them.

- The implementation follows the suggestions from [SDL documentation](https://wiki.libsdl.org/SDL_MouseWheelEvent#Remarks) : if SDL flagged the wheel as "flipped", we reverse the generated vector.

The rest should be rather straightforward.