### PR TITLE
Add a subscription to SDL.Event.TextInputEvent

### DIFF
--- a/src/Helm/Engine.hs
+++ b/src/Helm/Engine.hs
@@ -16,6 +16,7 @@ module Helm.Engine (
 ) where
 
 import Control.Monad.Trans.State (StateT)
+import Data.Text
 
 import FRP.Elerea.Param (SignalGen, Signal)
 import Linear.V2 (V2)
@@ -67,6 +68,9 @@ class Engine e where
 
   -- | The keyboard press signal, with events provided by the engine.
   keyboardPressSignal :: e -> SignalGen e (Signal [Key])
+
+  -- | The keyboard typing signal, with events provided by the engine
+  keyboardTypingSignal :: e -> SignalGen e (Signal [Text])
 
   -- | The window resize signal, with events provided by the engine.
   windowResizeSignal :: e -> SignalGen e (Signal [V2 Int])

--- a/src/Helm/Keyboard.hs
+++ b/src/Helm/Keyboard.hs
@@ -7,9 +7,12 @@ module Helm.Keyboard
   , presses
   , downs
   , ups
+  , typing
   ) where
 
 import FRP.Elerea.Param (input, snapshot)
+
+import Data.Text
 
 import Helm.Engine (Engine(..), Sub(..), Key(..))
 
@@ -44,3 +47,18 @@ ups f = Sub $ do
   engine <- input >>= snapshot
 
   fmap (fmap f) <$> keyboardUpSignal engine
+
+
+-- | Subscribe to keyboard typing events and map to a game action.
+-- While downs and ups report back keys pressed on the keyboard they fail to
+-- report ASCII letters (e.g. Shift+x will be reported as x rather than X).
+-- Hence the need for typing which will report back the character resulting from
+-- the various key combinations.
+typing
+    :: Engine e
+    => (Text -> a)  -- ^ The function to map the character typed to an action.
+    -> Sub e a      -- ^ The mapped subscription.
+typing f = Sub $ do
+    engine <- input >>= snapshot
+
+    fmap (fmap f) <$> keyboardTypingSignal engine


### PR DESCRIPTION
I'm working on a keyboard that is not the US standard layout (QWERTZ) for example SHIFT+4 is not $. So I cannot detect keys beyond the ones in [Helm.Keyboard](https://hackage.haskell.org/package/helm-1.0.0/docs/Helm-Keyboard.html), and that's a serious limitation to what I'm developing.

Therefore I propose this patch that exposes a subscription `Helm.Keyboard.typing :: Engine e => (Data.Text.Text -> a) -> Sub e a` which gets called whenever a key (or key combination) gets pressed with the argument being the resulting character. For example pressing shift and x would traditionally call twice `Helm.Keyboard.ups`, with this patch it will also call `Helm.Keyboard.typing` once with the text being X.

I also modified the helm-example-hello executable to demo this subscription. You can find the code on the branch `example-textinputevent` of my fork (or directly [here](https://github.com/geezee/helm/blob/example-textinputevent/examples/hello/Main.hs))